### PR TITLE
docs: add MCP Queen operational badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![macOS 13+](https://img.shields.io/badge/macOS-13%2B-blue)](https://local-mcp.com)
 [![GDPR](https://img.shields.io/badge/GDPR-compliant-green)](https://local-mcp.com/en/privacy)
 [![smithery badge](https://smithery.ai/badge/@lanchuske/local-mcp)](https://smithery.ai/server/@lanchuske/local-mcp)
+[![MCP Queen operational grade](https://mcpqueen.com/badge/com.local-mcp/local-mcp.svg)](https://mcpqueen.com/s/com.local-mcp/local-mcp)
 
 **Let your AI actually use your Mac.** Ask ChatGPT, Claude or Cursor to read & reply to your email, manage your calendar, text over iMessage, find your files, and pull data from PDFs — it just does it. It even reaches iMessage and your local apps that the web AIs can't. Tools run **on-device** — for desktop AIs nothing leaves your Mac; an optional, opt-in encrypted relay lets web AIs reach it. No API keys, free.
 


### PR DESCRIPTION
Adds the live MCP Queen operational-grade badge to the README, following the existing badge request in #33. The badge links to the current probe evidence and updates when that operational evidence changes. It describes observable MCP operations; it is not a security, privacy, data-quality, or compliance certification.