### PR TITLE
docs: report_bug → report_problem (la tool report_bug no existe)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ LMCP is proprietary software. The core binary is not open source and we don't ac
 
 Two ways:
 
-1. **From your AI client**: use the `report_bug` tool — it captures your version, macOS version, and logs automatically.
+1. **From your AI client**: use the `report_problem` tool — it captures your version, macOS version, and logs automatically.
 2. **GitHub Issue**: open an issue using the Bug Report template. Include your macOS version, LMCP version (visible in the menu bar tray), and relevant logs.
 
 ## Requesting features

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ This stops all background processes, removes the auto-start LaunchAgent, deletes
 
 ## Support
 
-- **In your AI client:** ask Claude to run `report_bug` or `request_feature`
+- **In your AI client:** ask Claude to run `report_problem` or `request_feature`
 - **GitHub:** [open an issue](https://github.com/lanchuske/local-mcp-releases/issues)
 - **Email:** [ctpo@colibird.co](mailto:ctpo@colibird.co)
 - **Website:** [local-mcp.com](https://local-mcp.com?ref=github)


### PR DESCRIPTION
`report_bug` **no existe**. La tool real es `report_problem` — verificado contra el catálogo del
server (`api/data_tools.json`), y el sweep de QA del repo principal de hecho verifica que
`report_bug` fue removido. El rename es de ~2026-06-11.

| archivo | línea | qué decía |
|---|---|---|
| `CONTRIBUTING.md` | 16 | *"use the `report_bug` tool"* |
| `README.md` | 300 | *"ask Claude to run `report_bug` or `request_feature`"* |

`request_feature` **sí existe** y queda intacto.

Este repo es público y esas dos líneas son la primera instrucción que ve alguien que quiere
reportar un problema: seguirla devuelve *"unknown tool"*.

Es la mitad pública de lanchuske/local-mcp#1512; la otra mitad (política de privacidad, 10
idiomas) va en lanchuske/local-mcp#1515.

No toca `package.json`, `server.js`, `glama.json` ni el headline del README, que son lo que
regenera `deploy-client`.
